### PR TITLE
fix: 使用import时ts报错：无法找到模块“vite-plugin-htmlx”的声明文件

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
如图，如果不在exports里面指定types的话，ts会找.mjs对应的.d.mts，要么把.mjs改成.js也可以，最后还是只加个types了，改动最小ԅ(¯﹃¯ԅ)
![image](https://github.com/skymoonya/vite-plugin-htmlx/assets/28592778/6c329535-5b40-4135-8c32-173180563246)
